### PR TITLE
Add CocoaPods podspec for a future version.

### DIFF
--- a/PSStackedView.podspec
+++ b/PSStackedView.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name     = 'PSStackedView'
+  s.version  = '0.1'
+  s.platform = :ios
+  s.summary  = 'Open source implementation of Twitter/iPad stacked ui - done right.'
+  s.homepage = 'https://github.com/steipete/PSStackedView'
+  s.author   = { 'Peter Steinberger' => 'steipete@gmail.com' }
+  s.source   = { :git => 'https://github.com/steipete/PSStackedView.git', :tag => '0.1' }
+
+  s.source_files = 'PSStackedView'
+  s.framework    = 'QuartzCore'
+  s.clean_paths  = 'Example'
+end


### PR DESCRIPTION
Adding this now will allow users to install the HEAD version directly from your repo.

Once you are ready to tag an actual release version, this copy can be updated for the chosen version number and be added to the [CocoaPods spec repo](https://github.com/alloy/cocoapods-specs). You can then bump the one in your repo to a unit higher, so that when users install from HEAD, they will have a higher version number than the released version.
