### PR TITLE
Fixed a crash when there is no reference left to lastController.

### DIFF
--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -921,7 +921,7 @@ enum {
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated; {
     PSSVLog(@"popping controller: %@ (#%d total, animated:%d)", [self topViewController], [self.viewControllers count], animated);
     
-    UIViewController *lastController = [self topViewController];
+    UIViewController *lastController = [[[self topViewController] retain] autorelease];
     if (lastController) {        
         [self delegateWillRemoveViewController:lastController];
         


### PR DESCRIPTION
lastController gets deallocated as soon as it gets removed from viewControllers_ and a dangling pointer gets returned.

Y U NO USE ARC ;) ?
