### PR TITLE
Update PSStackedView.podspec

### DIFF
--- a/PSStackedView.podspec
+++ b/PSStackedView.podspec
@@ -4,10 +4,11 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.summary  = 'Open source implementation of Twitter/iPad stacked UI - done right.'
   s.homepage = 'https://github.com/steipete/PSStackedView'
+  s.license  = 'MIT'
   s.author   = { 'Peter Steinberger' => 'steipete@gmail.com' }
   s.source   = { :git => 'https://github.com/steipete/PSStackedView.git', :tag => '1.0' }
 
+  s.requires_arc = true
   s.source_files = 'PSStackedView'
   s.framework    = 'QuartzCore'
-  s.clean_paths  = 'Example'
 end


### PR DESCRIPTION
Removes Clean paths, adds ARC requirement, and License

This spec passes lint and has been pushed to the Specs Repo
