### PR TITLE
Missing import for class

### DIFF
--- a/PSStackedView/UIView+PSSizes.h
+++ b/PSStackedView/UIView+PSSizes.h
@@ -6,6 +6,7 @@
 //  Copyright 2011 Peter Steinberger. All rights reserved.
 //
 
+#import <UIKit/UIView.h>
 
 @interface UIView (PSSizes)
 


### PR DESCRIPTION
When defining a category, the base class must be imported
