### PR TITLE
Fixed UIViewController.navigationController swizzling 

### DIFF
--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -120,10 +120,14 @@ typedef void(^PSSVSimpleBlock)(void);
     cornerRadius_ = 6.0f;
     
 #ifdef ALLOW_SWIZZLING_NAVIGATIONCONTROLLER
-    PSSVLog("Swizzling UIViewController.navigationController");
-    Method origMethod = class_getInstanceMethod([UIViewController class], @selector(navigationController));
-    Method overrideMethod = class_getInstanceMethod([UIViewController class], @selector(navigationControllerSwizzled));
-    method_exchangeImplementations(origMethod, overrideMethod);
+    static dispatch_once_t token;
+    
+    dispatch_once(&token, ^{
+        PSSVLog("Swizzling UIViewController.navigationController");
+        Method origMethod = class_getInstanceMethod([UIViewController class], @selector(navigationController));
+        Method overrideMethod = class_getInstanceMethod([UIViewController class], @selector(navigationControllerSwizzled));
+        method_exchangeImplementations(origMethod, overrideMethod);
+    });
 #endif
 
 }


### PR DESCRIPTION
Simple fix here.

If PSStackedViewController was created more than once, the swizzling was 
reverted every two creations.
