### PR TITLE
Feature: Add property ton enable panning over UIControls

### DIFF
--- a/PSStackedView/PSStackedViewController.h
+++ b/PSStackedView/PSStackedViewController.h
@@ -124,6 +124,9 @@ enum {
 /// enable scaling while fade in/out
 @property(nonatomic, assign) BOOL enableScalingFadeInOut;
 
+/// Property to enable panning when the touch starts in a UIControl (Defaults to NO).
+@property(nonatomic, assign) BOOL enablePanOverUIControls;
+
 // When true, overlaped views (with overlap ratio under kPSSVOverlapMinimalValueToApplyDarkRatio)
 // do not accept touches from user. But, when view is tapped (via UITapGestureRecognizer), the
 // stack is poped to this viewController

--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -66,6 +66,7 @@ typedef void(^PSSVSimpleBlock)(void);
 @synthesize enableShadows = enableShadows_;
 @synthesize enableDraggingPastInsets = enableDraggingPastInsets_;
 @synthesize enableScalingFadeInOut = enableScalingFadeInOut_;
+@synthesize enablePanOverUIControls = enablePanOverUIControls_;
 @synthesize defaultShadowWidth = defaultShadowWidth_;
 @synthesize defaultShadowAlpha  = defaultShadowAlpha_;
 @synthesize cornerRadius = cornerRadius_;
@@ -115,6 +116,7 @@ typedef void(^PSSVSimpleBlock)(void);
     enableShadows_ = YES;
     enableDraggingPastInsets_ = YES;
     enableScalingFadeInOut_ = YES;
+    enablePanOverUIControls_ = NO;
     defaultShadowWidth_ = 60.0f;
     defaultShadowAlpha_ = 0.2f;
     cornerRadius_ = 6.0f;
@@ -1586,13 +1588,18 @@ enum {
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
     
     BOOL shouldReceiveTouch = YES;
-    if ([touch.view isKindOfClass:[UIControl class]]) {
+    if ([touch.view isKindOfClass:[UIControl class]] && !enablePanOverUIControls_) {
         // prevent recognizing touches on the slider
         shouldReceiveTouch = NO;
     }
     if (shouldReceiveTouch) shouldReceiveTouch = [self shouldReceiveTouchForView:touch.view];
     
     return shouldReceiveTouch;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return enablePanOverUIControls_;
 }
 
 @end


### PR DESCRIPTION
I've added a property to PSStackedViewController to enable panning over UIControls. It is set to NO by default to preserve the previous behavior in order not to break existing apps.

I'm not sure about the name of the property, so feel free to suggest a better one.

I've tested it with UIButtons and UISlider. The panning takes over the slider when the view is still moving, but otherwise it works fine. Was there another UIControls that was giving problems?

Anyways I hope my contribution is worthy (although small) ;) And thanks for all the great projects you give!
