### PR TITLE
added property to disable "fast" panning with 1px finger moves

### DIFF
--- a/PSStackedView/PSStackedViewController.h
+++ b/PSStackedView/PSStackedViewController.h
@@ -113,6 +113,9 @@ enum {
 /// reduces animations to a minimum to get smoother reactions on frontmost view.
 @property(nonatomic, assign, getter=isReducingAnimations) BOOL reduceAnimations;
 
+/// Property to enable always snapping to nearest
+@property(nonatomic, assign) BOOL alwaysSnapToNearest;
+
 /// Property to disable bounces
 @property(nonatomic, assign) BOOL enableBounces;
 

--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -111,6 +111,7 @@ typedef void(^PSSVSimpleBlock)(void);
     
     [self configureGestureRecognizer];
     
+    _alwaysSnapToNearest = NO;
     enableBounces_ = YES;
     enableShadows_ = YES;
     enableDraggingPastInsets_ = YES;
@@ -952,6 +953,10 @@ enum {
 }
 
 - (PSSVSnapOption)snapOptionFromOffset:(NSInteger)offset {
+	if (self.alwaysSnapToNearest) {
+		return PSSVRoundNearest;
+	}
+
 	if (offset > 0) {
 		return SVSnapOptionRight;
 	}


### PR DESCRIPTION
always enable snapping to nearest.

I also thought about a threshold in minimum horizontal movement for the SVSnapOptionRight/Left to be active. Maybe another time, I'm fine with PSSVRoundNearest.
