### PR TITLE
When calculate size of view, use UIScreen.bounds instead of UIScreen.applicationFrame

### DIFF
--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -251,7 +251,7 @@ typedef void(^PSSVSimpleBlock)(void);
 
 - (CGRect)viewRect {
     // self.view.frame not used, it's wrong in viewWillAppear
-    CGRect viewRect = [[UIScreen mainScreen] applicationFrame];
+    CGRect viewRect = [[UIScreen mainScreen] bounds];
     return viewRect;
 }
 


### PR DESCRIPTION
Running the example project, the size of the pushed view seems incorrect:

![](http://f.cl.ly/items/472Z1c112Y3H1I0T3Y1k/iOS%20Simulator%20Screen%20shot%20Aug%2019,%202014,%2012.35.56%20PM.png)

This patch use main screen bounds instead of applicationFrame and solve the issue:

![](http://f.cl.ly/items/1D470c1H1Y190f2P2s0C/iOS%20Simulator%20Screen%20shot%20Aug%2019,%202014,%2012.37.32%20PM.png)
