### PR TITLE
Fixed view bounds for iOS 8

### DIFF
--- a/PSStackedView/PSStackedViewController.m
+++ b/PSStackedView/PSStackedViewController.m
@@ -251,8 +251,15 @@ typedef void(^PSSVSimpleBlock)(void);
 
 - (CGRect)viewRect {
     // self.view.frame not used, it's wrong in viewWillAppear
-    CGRect viewRect = [[UIScreen mainScreen] bounds];
-    return viewRect;
+    CGRect screenBounds = [UIScreen mainScreen].bounds;
+    CGRect portraitScreenBounds = screenBounds;
+    
+    if ((NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_1) && (PSIsLandscape())) {
+        portraitScreenBounds.size.width = screenBounds.size.height;
+        portraitScreenBounds.size.height = screenBounds.size.width;
+    }
+    
+    return portraitScreenBounds;
 }
 
 // return screen width


### PR DESCRIPTION
Under iOS 8 [UIScreen mainScreen].bounds are no longer locked to portrait orientation i.e. depend on the current interface orientation.

This is a quick & dirty fix that restores the expected behavior and guarantees that viewRect is always in portrait.
